### PR TITLE
Add ability to stream audio via TextToSpeechStream

### DIFF
--- a/cmd/codegen/main.go
+++ b/cmd/codegen/main.go
@@ -25,6 +25,8 @@ const (
 // Run 'go generate' after adding new methods with a '{{.ReceiverType}}' pointer receiver.
 
 package elevenlabs
+
+import "io"
 {{range .Functions}}
 func {{.FuncIdent}}{{.FuncParams}}{{.FuncResults}} {
 	{{if .FuncResults}}return {{end}}{{.MethodReceiver}}.{{.FuncIdent}}{{.FuncArgs}}
@@ -190,6 +192,8 @@ func exprToString(expr ast.Expr) string {
 		return fmt.Sprintf("*%s", exprToString(fieldType.X))
 	case *ast.FuncType:
 		return fmt.Sprintf("func%s%s", genTypedParams(fieldType.Params), genFuncReturnTypes(fieldType.Results))
+	case *ast.SelectorExpr:
+		return fmt.Sprintf("%s.%s", fieldType.X, fieldType.Sel)
 	}
 	return fmt.Sprintf("%s", expr)
 }

--- a/cmd/codegen/main_test.go
+++ b/cmd/codegen/main_test.go
@@ -129,6 +129,13 @@ func TestGenFuncFromMethod(t *testing.T) {
 			expArgsStr:   "()",
 			expResStr:    "",
 		},
+		{
+			name:         "9. Interface (and types) galore",
+			inSrc:        `func (b *Client) SampleMethod(w io.Writer, f *os.File) (r io.Reader,rw http.ResponseWriter) {}`,
+			expParamsStr: "(w io.Writer, f *os.File)",
+			expArgsStr:   "(w, f)",
+			expResStr:    " (io.Reader, http.ResponseWriter)",
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/elevenlabs_test.go
+++ b/elevenlabs_test.go
@@ -90,7 +90,7 @@ func TestRequestTimeout(t *testing.T) {
 	server := testServer(t, testServerConfig{
 		expectedMethod:      http.MethodPost,
 		expectedContentType: contentTypeJSON,
-		expectedAccept:      "application/json",
+		expectedAccept:      "*/*",
 		statusCode:          http.StatusOK,
 		responseDelay:       500 * time.Millisecond,
 	})
@@ -110,7 +110,7 @@ func TestAPIErrorOnBadRequestAndUnauthorized(t *testing.T) {
 			server := testServer(t, testServerConfig{
 				expectedMethod:      http.MethodGet,
 				expectedContentType: contentTypeJSON,
-				expectedAccept:      "application/json",
+				expectedAccept:      "*/*",
 				statusCode:          code,
 				responseBody:        testRespBodies["TestAPIErrorOnBadRequestAndUnauthorized"],
 			})
@@ -132,7 +132,7 @@ func TestValidationErrorOnUnprocessableEntity(t *testing.T) {
 	server := testServer(t, testServerConfig{
 		expectedMethod:      http.MethodPost,
 		expectedContentType: contentTypeJSON,
-		expectedAccept:      "application/json",
+		expectedAccept:      "*/*",
 		statusCode:          http.StatusUnprocessableEntity,
 		responseBody:        testRespBodies["TestValidationErrorOnUnprocessableEntity"],
 	})
@@ -152,7 +152,7 @@ func TestErrorOnUnexpectedStatusCode(t *testing.T) {
 	server := testServer(t, testServerConfig{
 		expectedMethod:      http.MethodPost,
 		expectedContentType: contentTypeJSON,
-		expectedAccept:      "application/json",
+		expectedAccept:      "*/*",
 		statusCode:          http.StatusInternalServerError,
 	})
 	defer server.Close()
@@ -236,7 +236,7 @@ func TestGetModels(t *testing.T) {
 	server := testServer(t, testServerConfig{
 		expectedMethod:      http.MethodGet,
 		expectedContentType: contentTypeJSON,
-		expectedAccept:      "application/json",
+		expectedAccept:      "*/*",
 		statusCode:          http.StatusOK,
 		responseBody:        respBody,
 	})
@@ -263,7 +263,7 @@ func TestGetVoices(t *testing.T) {
 	server := testServer(t, testServerConfig{
 		expectedMethod:      http.MethodGet,
 		expectedContentType: contentTypeJSON,
-		expectedAccept:      "application/json",
+		expectedAccept:      "*/*",
 		statusCode:          http.StatusOK,
 		responseBody:        respBody,
 	})
@@ -290,7 +290,7 @@ func TestGetDefaultVoiceSettings(t *testing.T) {
 	server := testServer(t, testServerConfig{
 		expectedMethod:      http.MethodGet,
 		expectedContentType: contentTypeJSON,
-		expectedAccept:      "application/json",
+		expectedAccept:      "*/*",
 		statusCode:          http.StatusOK,
 		responseBody:        respBody,
 	})
@@ -314,7 +314,7 @@ func TestGetVoiceSettings(t *testing.T) {
 	server := testServer(t, testServerConfig{
 		expectedMethod:      http.MethodGet,
 		expectedContentType: contentTypeJSON,
-		expectedAccept:      "application/json",
+		expectedAccept:      "*/*",
 		statusCode:          http.StatusOK,
 		responseBody:        respBody,
 	})
@@ -354,7 +354,7 @@ func TestGetVoice(t *testing.T) {
 			server := testServer(t, testServerConfig{
 				expectedMethod:      http.MethodGet,
 				expectedContentType: contentTypeJSON,
-				expectedAccept:      "application/json",
+				expectedAccept:      "*/*",
 				statusCode:          http.StatusOK,
 				responseBody:        []byte(respBody),
 			})
@@ -379,7 +379,7 @@ func TestDeleteVoice(t *testing.T) {
 	server := testServer(t, testServerConfig{
 		expectedMethod:      http.MethodDelete,
 		expectedContentType: contentTypeJSON,
-		expectedAccept:      "application/json",
+		expectedAccept:      "*/*",
 		statusCode:          http.StatusOK,
 	})
 	defer server.Close()
@@ -394,7 +394,7 @@ func TestEditVoiceSettings(t *testing.T) {
 	server := testServer(t, testServerConfig{
 		expectedMethod:      http.MethodPost,
 		expectedContentType: contentTypeJSON,
-		expectedAccept:      "application/json",
+		expectedAccept:      "*/*",
 		statusCode:          http.StatusOK,
 	})
 	defer server.Close()
@@ -436,7 +436,7 @@ func TestAddVoice(t *testing.T) {
 			server := testServer(t, testServerConfig{
 				expectedMethod:      http.MethodPost,
 				expectedContentType: contentMultipart,
-				expectedAccept:      "application/json",
+				expectedAccept:      "*/*",
 				statusCode:          http.StatusOK,
 				responseBody:        tc.expRespBody,
 			})
@@ -466,7 +466,7 @@ func TestEditVoice(t *testing.T) {
 	server := testServer(t, testServerConfig{
 		expectedMethod:      http.MethodPost,
 		expectedContentType: contentMultipart,
-		expectedAccept:      "application/json",
+		expectedAccept:      "*/*",
 		statusCode:          http.StatusOK,
 	})
 	defer server.Close()
@@ -481,7 +481,7 @@ func TestDeleteSample(t *testing.T) {
 	server := testServer(t, testServerConfig{
 		expectedMethod:      http.MethodDelete,
 		expectedContentType: contentTypeJSON,
-		expectedAccept:      "application/json",
+		expectedAccept:      "*/*",
 		statusCode:          http.StatusOK,
 	})
 	defer server.Close()
@@ -498,7 +498,7 @@ func TestGetSampleAudio(t *testing.T) {
 	server := testServer(t, testServerConfig{
 		expectedMethod:      http.MethodGet,
 		expectedContentType: contentTypeJSON,
-		expectedAccept:      "application/json",
+		expectedAccept:      "*/*",
 		statusCode:          http.StatusOK,
 		responseBody:        []byte(expRespBody),
 	})
@@ -546,7 +546,7 @@ func TestGetHistory(t *testing.T) {
 				keyOptional:         false,
 				expectedMethod:      "GET",
 				expectedContentType: "application/json",
-				expectedAccept:      "application/json",
+				expectedAccept:      "*/*",
 				expectedQueryStr:    tc.expQueryString,
 				statusCode:          http.StatusOK,
 				responseBody:        tc.respBody,
@@ -601,7 +601,7 @@ func TestGetHistoryItem(t *testing.T) {
 	server := testServer(t, testServerConfig{
 		expectedMethod:      http.MethodGet,
 		expectedContentType: contentTypeJSON,
-		expectedAccept:      "application/json",
+		expectedAccept:      "*/*",
 		statusCode:          http.StatusOK,
 		responseBody:        respBody,
 	})
@@ -624,7 +624,7 @@ func TestDeleteHistoryItem(t *testing.T) {
 	server := testServer(t, testServerConfig{
 		expectedMethod:      http.MethodDelete,
 		expectedContentType: contentTypeJSON,
-		expectedAccept:      "application/json",
+		expectedAccept:      "*/*",
 		statusCode:          http.StatusOK,
 	})
 	defer server.Close()
@@ -640,7 +640,7 @@ func TestGetHistoryItemAudio(t *testing.T) {
 	server := testServer(t, testServerConfig{
 		expectedMethod:      http.MethodGet,
 		expectedContentType: contentTypeJSON,
-		expectedAccept:      "application/json",
+		expectedAccept:      "*/*",
 		statusCode:          http.StatusOK,
 		responseBody:        []byte(expRespBody),
 	})
@@ -682,7 +682,7 @@ func TestGetSubscription(t *testing.T) {
 	server := testServer(t, testServerConfig{
 		expectedMethod:      http.MethodGet,
 		expectedContentType: contentTypeJSON,
-		expectedAccept:      "application/json",
+		expectedAccept:      "*/*",
 		statusCode:          http.StatusOK,
 		responseBody:        respBody,
 	})
@@ -706,7 +706,7 @@ func TestGetUser(t *testing.T) {
 	server := testServer(t, testServerConfig{
 		expectedMethod:      http.MethodGet,
 		expectedContentType: contentTypeJSON,
-		expectedAccept:      "application/json",
+		expectedAccept:      "*/*",
 		statusCode:          http.StatusOK,
 		responseBody:        respBody,
 	})

--- a/shorthand.go
+++ b/shorthand.go
@@ -3,8 +3,14 @@
 
 package elevenlabs
 
+import "io"
+
 func TextToSpeech(voiceID string, ttsReq TextToSpeechRequest, queries ...QueryFunc) ([]byte, error) {
 	return getDefaultClient().TextToSpeech(voiceID, ttsReq, queries...)
+}
+
+func TextToSpeechStream(streamWriter io.Writer, voiceID string, ttsReq TextToSpeechRequest, queries ...QueryFunc) error {
+	return getDefaultClient().TextToSpeechStream(streamWriter, voiceID, ttsReq, queries...)
 }
 
 func GetModels() ([]Model, error) {


### PR DESCRIPTION
Includes refactoring doRequest to `Copy` the request body to a writer rather than reading it all.