### PR TITLE
Add error handling for http status 429

### DIFF
--- a/client.go
+++ b/client.go
@@ -116,7 +116,7 @@ func (c *Client) doRequest(ctx context.Context, RespBodyWriter io.Writer, method
 			return err
 		}
 		switch resp.StatusCode {
-		case http.StatusBadRequest, http.StatusUnauthorized:
+		case http.StatusBadRequest, http.StatusUnauthorized, http.StatusTooManyRequests:
 			apiErr := &APIError{}
 			if err := json.Unmarshal(respBody, apiErr); err != nil {
 				return err


### PR DESCRIPTION
https://help.elevenlabs.io/hc/en-us/articles/19571824571921-API-Error-Code-429

Useful for determining if 429 is being thrown because of excessive concurrent requests or a busy Elevenlabs server. example response:

```
{
  "detail": {
    "status": "too_many_concurrent_requests",
    "message": "Too many concurrent requests. Your current subscription is associated with a maximum of 5 concurrent requests (running in parallel). This is done such that a single user does not overwhelm our systems and affect other users negatively. Please upgrade your subscription or contact sales if you want to increase this limit."
  }
}
```